### PR TITLE
nvmeof-recoverer: add failure domain configuration for CRUSH location

### DIFF
--- a/pkg/daemon/ceph/osd/device.go
+++ b/pkg/daemon/ceph/osd/device.go
@@ -49,6 +49,7 @@ type DesiredDevice struct {
 	InitialWeight      string
 	IsFilter           bool
 	IsDevicePathFilter bool
+	FailureDomain      string
 }
 
 // DeviceOsdMapping represents the mapping of an OSD on disk

--- a/pkg/operator/ceph/cluster/osd/config/config.go
+++ b/pkg/operator/ceph/cluster/osd/config/config.go
@@ -33,6 +33,7 @@ const (
 	DeviceClassKey     = "deviceClass"
 	InitialWeightKey   = "initialWeight"
 	PrimaryAffinityKey = "primaryAffinity"
+	FailureDomainKey   = "failureDomain"
 )
 
 // StoreConfig represents the configuration of an OSD on a device.
@@ -46,6 +47,7 @@ type StoreConfig struct {
 	InitialWeight   string `json:"initialWeight,omitempty"`
 	PrimaryAffinity string `json:"primaryAffinity,omitempty"`
 	StoreType       string `json:"storeType,omitempty"`
+	FailureDomain   string `json:"failureDomain,omitempty"`
 }
 
 func (s StoreConfig) IsValidStoreType() bool {
@@ -91,6 +93,8 @@ func ToStoreConfig(config map[string]string) StoreConfig {
 			storeConfig.InitialWeight = v
 		case PrimaryAffinityKey:
 			storeConfig.PrimaryAffinity = v
+		case FailureDomainKey:
+			storeConfig.FailureDomain = v
 		}
 	}
 

--- a/pkg/operator/ceph/nvmeof_recoverer/nvmeofstorage/controller.go
+++ b/pkg/operator/ceph/nvmeof_recoverer/nvmeofstorage/controller.go
@@ -319,8 +319,12 @@ func (r *ReconcileNvmeOfStorage) updateCephClusterCR(request reconcile.Request, 
 			cephCluster.Spec.Storage.Nodes[i].Devices = filteredDevices
 		} else if node.Name == newDeviceInfo.AttachedNode {
 			// Add the new device to the new node
+			fabricHost := FabricFailureDomainPrefix + "-" + r.nvmeOfStorage.Spec.Name
 			newDevice := cephv1.Device{
 				Name: newDeviceInfo.DeviceName,
+				Config: map[string]string{
+					"failureDomain": fabricHost,
+				},
 			}
 			// Check for existing device with the same name
 			for _, device := range node.Devices {

--- a/pkg/operator/test/client.go
+++ b/pkg/operator/test/client.go
@@ -48,14 +48,24 @@ func New(t *testing.T, nodes int) *fake.Clientset {
 
 // AddReadyNode adds a new Node with status "Ready" and the given name and IP.
 func AddReadyNode(t *testing.T, clientset *fake.Clientset, name, ip string) {
+	AddReadyNodeWithLabels(t, clientset, name, ip, map[string]string{})
+}
+
+// AddReadyNodeWithLabels adds a new Node with additional labels
+func AddReadyNodeWithLabels(t *testing.T, clientset *fake.Clientset, name, ip string, additionalLabels map[string]string) {
 	t.Helper()
 	ready := corev1.NodeCondition{Type: corev1.NodeReady, Status: corev1.ConditionTrue}
+	labels := map[string]string{
+		corev1.LabelHostname: name,
+	}
+	for key, value := range additionalLabels {
+		labels[key] = value
+	}
+
 	n := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: map[string]string{
-				corev1.LabelHostname: name,
-			},
-			Name: name,
+			Labels: labels,
+			Name:   name,
 		},
 		Status: corev1.NodeStatus{
 			Conditions: []corev1.NodeCondition{


### PR DESCRIPTION
- added failureDomain to specify osds using fabric failure domains
- modified osd Provisioning to use the defined failure domain for CRUSH location if config is set

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
