### PR TITLE
nvmeof-recoverer: fix `reconstructCRUSHMap` and `runNvmeoFJob()` to work correctly

### DIFF
--- a/pkg/operator/ceph/nvmeof_recoverer/clustermanager/handler.go
+++ b/pkg/operator/ceph/nvmeof_recoverer/clustermanager/handler.go
@@ -34,18 +34,17 @@ import time
 
 
 def get_nvme_devices():
-	result = subprocess.run(['nvme', 'list', '-o', 'json'],
-							stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-	devices = json.loads(result.stdout)
-	devices = {device['DevicePath'] for device in devices['Devices']}
-	return devices
+    result = subprocess.run(['nvme', 'list', '-o', 'json'],
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    devices = json.loads(result.stdout)
+    return {device['DevicePath'] for device in devices.get('Devices', [])}
 
 def connect_nvme(subnqn, ip_address, port):
-	try:
-		devices_before = get_nvme_devices()
-		subprocess.run(['nvme', 'connect', '-t', 'tcp', '-n', subnqn,
-						'-a', ip_address, '-s', port], check=True)
-		time.sleep(1)
+    try:
+        devices_before = get_nvme_devices()
+        subprocess.run(['nvme', 'connect', '-t', 'tcp', '-n', subnqn,
+                        '-a', ip_address, '-s', port], check=True)
+        time.sleep(1)
     except subprocess.CalledProcessError as e:
         print('FAILED:', e)
     finally:
@@ -58,25 +57,23 @@ def connect_nvme(subnqn, ip_address, port):
             print('FAILED: No new devices connected.')
 
 def disconnect_nvme(subnqn):
-
-	try:
-		result = subprocess.run(['nvme', 'disconnect', '-n', subnqn],
-								stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-		output = result.stdout.strip()
-		print(output)
-	except subprocess.CalledProcessError as e:
-		print('FAILED:', e)
+    try:
+        result = subprocess.run(['nvme', 'disconnect', '-n', subnqn],
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output = result.stdout.strip()
+        print(output)
+    except subprocess.CalledProcessError as e:
+        print('FAILED:', e)
 
 mode = "%s"
 address = "%s"
 port = "%s"
 subnqn = "%s"
 
-if mode and subnqn and address and port:
-    if mode == 'connect':
-        connect_nvme(subnqn, address, port)
-    elif mode == 'disconnect':
-        disconnect_nvme(subnqn)
+if mode == 'connect':
+    connect_nvme(subnqn, address, port)
+elif mode == 'disconnect':
+    disconnect_nvme(subnqn)
 `
 )
 


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
