### PR TITLE
[PBDEV-1649] fix nvme-of disconnect job to properly handle failures

### DIFF
--- a/pkg/operator/ceph/nvmeof_recoverer/clustermanager/handler.go
+++ b/pkg/operator/ceph/nvmeof_recoverer/clustermanager/handler.go
@@ -60,8 +60,11 @@ def disconnect_nvme(subnqn):
     try:
         result = subprocess.run(['nvme', 'disconnect', '-n', subnqn],
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        output = result.stdout.strip()
-        print(output)
+        output = result.stdout.decode('utf-8').strip()
+        if "disconnected 0 controller(s)" in output:
+            print('FAILED:', output)
+        else:
+            print(output)
     except subprocess.CalledProcessError as e:
         print('FAILED:', e)
 
@@ -213,10 +216,10 @@ func (cm *ClusterManager) runNvmeoFJob(mode, namespace, targetHost, address, por
 		logger.Errorf("failed to get logs. host: %s, err: %v", targetHost, err)
 		return "", err
 	}
-	if strings.HasPrefix(output, "FAILED:") {
-		return "", errors.New(output)
+	if strings.Contains(output, "FAILED:") {
+		return "", errors.New(fmt.Sprintf("target=%s, output: %s", targetHost, output))
 	}
 
-	logger.Debug("Successfully executed nvmeof connect/disconnect job. output: %s", output)
+	logger.Debugf("Successfully executed nvmeof connect/disconnect job. output: %s", output)
 	return output, nil
 }


### PR DESCRIPTION
- fixed disconnect jobs correctly send fail messages
- fixed the handler to properly detect fail messages

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
