### PR TITLE
[PBDEV-1764] Fix nvme-of connect issues by updating fabric map and ignoring extra kernal messages

### DIFF
--- a/pkg/operator/ceph/nvmeof_recoverer/nvmeofstorage/util.go
+++ b/pkg/operator/ceph/nvmeof_recoverer/nvmeofstorage/util.go
@@ -46,12 +46,12 @@ def get_nvme_devices():
 
 def connect_nvme(subnqn, ip_address, port):
     devices_before = get_nvme_devices()
-    subprocess.run(['nvme', 'connect', '-t', 'tcp', '-n', subnqn, '-a', ip_address, '-s', port], check=True)
+    subprocess.run(['nvme', 'connect', '-t', 'tcp', '-n', subnqn, '-a', ip_address, '-s', port], stdout=subprocess.DEVNULL, check=True)
     time.sleep(1)
     devices_after = get_nvme_devices()
     new_devices = devices_after - devices_before
-    if new_devices:
-        print('SUCCESS:', '\\n'.join(new_devices))
+    if len(new_devices) == 1:
+        print('SUCCESS:', list(new_devices)[0])
     else:
         print('FAILED: No new devices connected.')
 


### PR DESCRIPTION
- added stdout=subprocess.DEVNULL to subprocess.run to ignore additional messages
- modified nvmeof connect job to always return the newly added nvme device path in successful cases
- trimmed output in runNvmeoFJob function to remove any surrounding whitespace

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
