### PR TITLE
[PBDEV-1479] add support for multi domain in fabric map handling

### DIFF
--- a/pkg/operator/ceph/nvmeof_recoverer/clustermanager/handler_test.go
+++ b/pkg/operator/ceph/nvmeof_recoverer/clustermanager/handler_test.go
@@ -15,78 +15,218 @@ func TestReassignOSD(t *testing.T) {
 	cm := New(ctx, opManagerContext)
 
 	t.Run("TestGetNextAttachableHost", func(t *testing.T) {
-		nvmeofstorage := &cephv1.NvmeOfStorage{
-			Spec: cephv1.NvmeOfStorageSpec{
-				Devices: []cephv1.FabricDevice{
-					{
-						OsdID:        "0",
-						AttachedNode: "node1",
-					},
-					{
-						OsdID:        "1",
-						AttachedNode: "node2",
-					},
-					{
-						OsdID:        "2",
-						AttachedNode: "node2",
-					},
-					{
-						OsdID:        "3",
-						AttachedNode: "node3",
+		// Given: a FabricMap with 4 OSDs attached to 3 different nodes
+		nvmeofstorages := map[string]*cephv1.NvmeOfStorage{
+			"domain1": {
+				Spec: cephv1.NvmeOfStorageSpec{
+					Name: "domain1",
+					Devices: []cephv1.FabricDevice{
+						{
+							OsdID:        "0",
+							AttachedNode: "node1",
+						},
+						{
+							OsdID:        "1",
+							AttachedNode: "node2",
+						},
+						{
+							OsdID:        "2",
+							AttachedNode: "node2",
+						},
+						{
+							OsdID:        "3",
+							AttachedNode: "node3",
+						},
 					},
 				},
 			},
 		}
-		cm.AddOSD(nvmeofstorage.Spec.Devices[0].OsdID, nvmeofstorage)
-		cm.AddOSD(nvmeofstorage.Spec.Devices[1].OsdID, nvmeofstorage)
-		cm.AddOSD(nvmeofstorage.Spec.Devices[2].OsdID, nvmeofstorage)
-		cm.AddOSD(nvmeofstorage.Spec.Devices[3].OsdID, nvmeofstorage)
+		for domainName, nvmeofstorage := range nvmeofstorages {
+			for _, device := range nvmeofstorage.Spec.Devices {
+				cm.AddOSD(device.OsdID, domainName, nvmeofstorages)
+			}
+		}
 
+		// Check if the OSDs are added correctly
+		targetDomain := "domain1"
 		expectedOSDIDs := []string{"0"}
-		actualOSDs, _ := cm.fabricMap.FindOSDsByNode("node1")
+		actualOSDs, _ := cm.fabricMap.FindOSDsByNode(targetDomain, "node1")
 		CheckOSDIDs(t, expectedOSDIDs, actualOSDs)
 
 		expectedOSDIDs = []string{"1", "2"}
-		actualOSDs, _ = cm.fabricMap.FindOSDsByNode("node2")
+		actualOSDs, _ = cm.fabricMap.FindOSDsByNode(targetDomain, "node2")
 		CheckOSDIDs(t, expectedOSDIDs, actualOSDs)
 
 		expectedOSDIDs = []string{"3"}
-		actualOSDs, _ = cm.fabricMap.FindOSDsByNode("node3")
+		actualOSDs, _ = cm.fabricMap.FindOSDsByNode(targetDomain, "node3")
 		CheckOSDIDs(t, expectedOSDIDs, actualOSDs)
 	})
 
 	t.Run("TestGetNextAttachableHostErrorHandling", func(t *testing.T) {
+		// Test with invalid osdID, it should return an error
+		targetDomain := "domain1"
 		osdID := "invalidValue"
-		actualNextNode, err := cm.GetNextAttachableHost(osdID)
+		_, err := cm.GetNextAttachableHost(osdID, targetDomain)
 		expectedNextNode := ""
 		require.Error(t, err)
-		require.Equal(t, expectedNextNode, actualNextNode)
 
+		// Test with correct osdID, it should return an attachable node
 		osdID = "0"
-		actualNextNode, err = cm.GetNextAttachableHost(osdID)
+		actualNextNode, err := cm.GetNextAttachableHost(osdID, targetDomain)
 		expectedNextNode = "node3"
 		require.Nil(t, err)
 		require.Equal(t, expectedNextNode, actualNextNode)
 
+		// Test with correct osdID, it should return an attachable node
 		osdID = "3"
-		actualNextNode, err = cm.GetNextAttachableHost(osdID)
+		actualNextNode, err = cm.GetNextAttachableHost(osdID, targetDomain)
 		expectedNextNode = "node2"
 		require.Nil(t, err)
 		require.Equal(t, expectedNextNode, actualNextNode)
 
+		// Test with correct osdID when there is no attachable node, it should return an empty string
 		osdID = "1"
-		actualNextNode, err = cm.GetNextAttachableHost(osdID)
+		actualNextNode, err = cm.GetNextAttachableHost(osdID, targetDomain)
 		expectedNextNode = ""
 		require.Nil(t, err)
 		require.Equal(t, expectedNextNode, actualNextNode)
 
+		// Test with correct osdID when there is no attachable node, it should return an empty string
 		osdID = "2"
-		actualNextNode, err = cm.GetNextAttachableHost(osdID)
+		actualNextNode, err = cm.GetNextAttachableHost(osdID, targetDomain)
+		expectedNextNode = ""
+		require.Nil(t, err)
+		require.Equal(t, expectedNextNode, actualNextNode)
+	})
+
+	t.Run("TestGetNextAttachableHostWithMultiDomain", func(t *testing.T) {
+		// Given: a FabricMap with 6 OSDs attached to 3 different nodes in 2 different domains
+		nvmeofstorages := map[string]*cephv1.NvmeOfStorage{
+			"domain1": {
+				Spec: cephv1.NvmeOfStorageSpec{
+					Name: "domain1",
+					Devices: []cephv1.FabricDevice{
+						{
+							OsdID:        "0",
+							AttachedNode: "node1",
+						},
+						{
+							OsdID:        "1",
+							AttachedNode: "node2",
+						},
+						{
+							OsdID:        "2",
+							AttachedNode: "node2",
+						},
+						{
+							OsdID:        "3",
+							AttachedNode: "node3",
+						},
+					},
+				},
+			},
+			"domain2": {
+				Spec: cephv1.NvmeOfStorageSpec{
+					Name: "domain2",
+					Devices: []cephv1.FabricDevice{
+						{
+							OsdID:        "4",
+							AttachedNode: "node1",
+						},
+						{
+							OsdID:        "5",
+							AttachedNode: "node2",
+						},
+					},
+				},
+			},
+		}
+		for domainName, nvmeofstorage := range nvmeofstorages {
+			for _, device := range nvmeofstorage.Spec.Devices {
+				cm.AddOSD(device.OsdID, domainName, nvmeofstorages)
+			}
+		}
+
+		// Check if the OSDs are added correctly
+		targetDomain := "domain1"
+		expectedOSDIDs := []string{"0"}
+		actualOSDs, _ := cm.fabricMap.FindOSDsByNode(targetDomain, "node1")
+		CheckOSDIDs(t, expectedOSDIDs, actualOSDs)
+
+		expectedOSDIDs = []string{"1", "2"}
+		actualOSDs, _ = cm.fabricMap.FindOSDsByNode(targetDomain, "node2")
+		CheckOSDIDs(t, expectedOSDIDs, actualOSDs)
+
+		expectedOSDIDs = []string{"3"}
+		actualOSDs, _ = cm.fabricMap.FindOSDsByNode(targetDomain, "node3")
+		CheckOSDIDs(t, expectedOSDIDs, actualOSDs)
+
+		targetDomain = "domain2"
+		expectedOSDIDs = []string{"4"}
+		actualOSDs, _ = cm.fabricMap.FindOSDsByNode(targetDomain, "node1")
+		CheckOSDIDs(t, expectedOSDIDs, actualOSDs)
+
+		expectedOSDIDs = []string{"5"}
+		actualOSDs, _ = cm.fabricMap.FindOSDsByNode(targetDomain, "node2")
+		CheckOSDIDs(t, expectedOSDIDs, actualOSDs)
+
+		// Test with correct osdID, it should return an attachable node
+		targetDomain = "domain1"
+		osdID := "0"
+		actualNextNode, err := cm.GetNextAttachableHost(osdID, targetDomain)
+		expectedNextNode := "node3"
+		require.Nil(t, err)
+		require.Equal(t, expectedNextNode, actualNextNode)
+
+		// Test with wrong domain name, it should return an error
+		targetDomain = "domain1"
+		osdID = "4"
+		_, err = cm.GetNextAttachableHost(osdID, targetDomain)
+		require.Error(t, err)
+
+		// Test with correct osdID, it should return an attachable node from domain2
+		// if actualNextNode is "node1" that means FabricMap is not considering domain name
+		targetDomain = "domain2"
+		osdID = "4"
+		actualNextNode, err = cm.GetNextAttachableHost(osdID, targetDomain)
+		expectedNextNode = "node2"
+		require.Nil(t, err)
+		require.Equal(t, expectedNextNode, actualNextNode)
+
+		// Test with correct osdID, it should return an attachable node
+		targetDomain = "domain1"
+		osdID = "1"
+		actualNextNode, err = cm.GetNextAttachableHost(osdID, targetDomain)
+		expectedNextNode = "node3"
+		require.Nil(t, err)
+		require.Equal(t, expectedNextNode, actualNextNode)
+
+		// Test if this domain has no more attachable host, it should return an empty string
+		targetDomain = "domain2"
+		osdID = "5"
+		actualNextNode, err = cm.GetNextAttachableHost(osdID, targetDomain)
+		expectedNextNode = ""
+		require.Nil(t, err)
+		require.Equal(t, expectedNextNode, actualNextNode)
+
+		// Test with correct osdID, it should return an attachable node
+		targetDomain = "domain1"
+		osdID = "2"
+		actualNextNode, err = cm.GetNextAttachableHost(osdID, targetDomain)
+		expectedNextNode = "node3"
+		require.Nil(t, err)
+		require.Equal(t, expectedNextNode, actualNextNode)
+
+		// Test if this domain has no more attachable host, it should return an empty string
+		targetDomain = "domain1"
+		osdID = "3"
+		actualNextNode, err = cm.GetNextAttachableHost(osdID, targetDomain)
 		expectedNextNode = ""
 		require.Nil(t, err)
 		require.Equal(t, expectedNextNode, actualNextNode)
 	})
 }
+
 func CheckOSDIDs(t *testing.T, expectedOSDIDs []string, actualOSDs []FabricOSDInfo) {
 	acutalOSDIDs := []string{}
 	for _, osd := range actualOSDs {


### PR DESCRIPTION
- updated the fabricMap to be categorized by domain name
- modified the `GetNextAttachableHost()` function to return attachable nodes according to the domain-specific fabricMap
- added integration test scenarios to validate the functionality of multi domain support

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
