### PR TITLE
[PBDEV-1777] Fix `reconstructCRUSHMap()` to include `root` for fabric domain

### DIFF
--- a/pkg/operator/ceph/nvmeof_recoverer/nvmeofstorage/controller.go
+++ b/pkg/operator/ceph/nvmeof_recoverer/nvmeofstorage/controller.go
@@ -255,11 +255,12 @@ func (r *ReconcileNvmeOfStorage) reconstructCRUSHMap(context context.Context, na
 				if pod.Spec.NodeName == device.AttachedNode && envVar.Name == "ROOK_BLOCK_PATH" && envVar.Value == device.DeviceName {
 					device.OsdID = pod.Labels["ceph-osd-id"]
 					clusterName = pod.Labels["app.kubernetes.io/part-of"]
+					crushRoot := pod.Labels["topology-location-root"]
 
 					// Update CRUSH map for OSD relocation to fabric failure domain
 					fabricHost := FabricFailureDomainPrefix + "-" + r.nvmeOfStorage.Spec.Name
 					clusterInfo := cephclient.AdminClusterInfo(context, namespace, clusterName)
-					cmd := []string{"osd", "crush", "move", "osd." + device.OsdID, "host=" + fabricHost}
+					cmd := []string{"osd", "crush", "move", fmt.Sprintf("osd.%s", device.OsdID), fmt.Sprintf("root=%s", crushRoot), fmt.Sprintf("host=%s", fabricHost)}
 					exec := cephclient.NewCephCommand(r.context, clusterInfo, cmd)
 					exec.JsonOutput = true
 					buf, err := exec.Run()


### PR DESCRIPTION

- added retrieval of the 'topology-location-root' label from the pod
- modified the crush map move command to include the root parameter

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
