### PR TITLE
[PBDEV-1748] Refactor to use only `FabricDescriptor` instead of `nvmeofstorage` CRD

### DIFF
--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -13155,17 +13155,15 @@ spec:
               type: object
             spec:
               properties:
+                clusterName:
+                  type: string
                 devices:
                   items:
                     description: FabricDevice represents a fabric device connected to a node
                     properties:
                       attachedNode:
                         type: string
-                      clusterName:
-                        type: string
                       deviceName:
-                        type: string
-                      osdID:
                         type: string
                       port:
                         type: integer
@@ -13183,6 +13181,7 @@ spec:
                 name:
                   type: string
               required:
+                - clusterName
                 - devices
                 - ip
                 - name

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -13141,17 +13141,15 @@ spec:
               type: object
             spec:
               properties:
+                clusterName:
+                  type: string
                 devices:
                   items:
                     description: FabricDevice represents a fabric device connected to a node
                     properties:
                       attachedNode:
                         type: string
-                      clusterName:
-                        type: string
                       deviceName:
-                        type: string
-                      osdID:
                         type: string
                       port:
                         type: integer
@@ -13169,6 +13167,7 @@ spec:
                 name:
                   type: string
               required:
+                - clusterName
                 - devices
                 - ip
                 - name

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -3264,7 +3264,6 @@ type FabricDevice struct {
 	Port         int    `json:"port"`
 	AttachedNode string `json:"attachedNode"`
 	DeviceName   string `json:"deviceName"`
-	OsdID        string `json:"osdID,omitempty"`
 }
 
 // NvmeOfStorageList contains a list of NvmeOfOSD

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -3247,9 +3247,10 @@ type NvmeOfStorage struct {
 }
 
 type NvmeOfStorageSpec struct {
-	Name    string         `json:"name"`
-	IP      string         `json:"ip"`
-	Devices []FabricDevice `json:"devices"`
+	Name        string         `json:"name"`
+	IP          string         `json:"ip"`
+	Devices     []FabricDevice `json:"devices"`
+	ClusterName string         `json:"clusterName"`
 }
 
 // NvmeOfStorageStatus defines the observed state of NvmeOStorage
@@ -3264,7 +3265,6 @@ type FabricDevice struct {
 	AttachedNode string `json:"attachedNode"`
 	DeviceName   string `json:"deviceName"`
 	OsdID        string `json:"osdID,omitempty"`
-	ClusterName  string `json:"clusterName,omitempty"`
 }
 
 // NvmeOfStorageList contains a list of NvmeOfOSD

--- a/pkg/operator/ceph/nvmeof_recoverer/nvmeofstorage/controller.go
+++ b/pkg/operator/ceph/nvmeof_recoverer/nvmeofstorage/controller.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"emperror.dev/errors"
@@ -180,10 +181,6 @@ func (r *ReconcileNvmeOfStorage) initFabricMap(context context.Context, request 
 
 	r.reconstructCRUSHMap(context, request.Namespace)
 
-	// Update the NvmeOfStorage CR to reflect the OSD ID
-	if err := r.client.Update(context, r.nvmeOfStorage); err != nil {
-		panic(fmt.Sprintf("Failed to update NVMeOfStorage: %v, Namespace: %s, Name: %s", err, request.Namespace, request.Name))
-	}
 	return nil
 }
 
@@ -192,16 +189,16 @@ func (r *ReconcileNvmeOfStorage) tryRelocateDevice(request reconcile.Request) er
 	osdID := strings.Split(strings.TrimPrefix(request.Name, osd.AppName+"-"), "-")[0]
 
 	// Get the fabric device descriptor for the given osdID
-	deviceInfo := r.findTargetNvmeOfStorageCR(osdID)
+	fd := r.findTargetDescriptor(request.Namespace, osdID)
 
 	// Cleanup the OSD that is in CrashLoopBackOff
-	r.cleanupOSD(request.Namespace, deviceInfo)
+	r.cleanupOSD(request.Namespace, fd)
 
 	// Connect the device to the new attachable node
-	newDeviceInfo := r.reassignFaultedOSDDevice(request.Namespace, deviceInfo)
+	newDeviceInfo := r.reassignFaultedOSDDevice(request.Namespace, fd)
 
 	// Request the OSD to be transferred to the next node
-	return r.updateCephClusterCR(request.Namespace, deviceInfo, newDeviceInfo)
+	return r.updateCephClusterCR(request.Namespace, fd, newDeviceInfo)
 }
 
 func (r *ReconcileNvmeOfStorage) Reconcile(context context.Context, request reconcile.Request) (reconcile.Result, error) {
@@ -262,20 +259,18 @@ func (r *ReconcileNvmeOfStorage) reconstructCRUSHMap(context context.Context, na
 						device.OsdID, device.AttachedNode, fabricHost)
 
 					// Update the OSD deployment depending on the nvmeofstorage CR
-					r.fabricMap.AddOSD(device.OsdID, r.nvmeOfStorage)
+					r.fabricMap.AddDescriptor(FabricDescriptor{
+						ID:           device.OsdID,
+						Address:      r.nvmeOfStorage.Spec.IP,
+						Port:         strconv.Itoa(device.Port),
+						SubNQN:       device.SubNQN,
+						AttachedNode: device.AttachedNode,
+						ClusterName:  clusterName,
+					})
 				}
 			}
 		}
 	}
-}
-
-func (r *ReconcileNvmeOfStorage) findTargetNvmeOfStorageCR(osdID string) cephv1.FabricDevice {
-	for _, device := range r.nvmeOfStorage.Spec.Devices {
-		if device.OsdID == osdID {
-			return device
-		}
-	}
-	panic("no attached node found")
 }
 
 func (r *ReconcileNvmeOfStorage) getPods(context context.Context, namespace string, opts metav1.ListOptions) *corev1.PodList {
@@ -286,10 +281,40 @@ func (r *ReconcileNvmeOfStorage) getPods(context context.Context, namespace stri
 	return pods
 }
 
+// findTargetDescriptor finds the attached device for the given OSD ID
+func (r *ReconcileNvmeOfStorage) findTargetDescriptor(namespace, osdID string) FabricDescriptor {
+	opts := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("ceph-osd-id=%s", osdID),
+	}
+	pods, err := r.context.Clientset.CoreV1().Pods(namespace).List(r.opManagerContext, opts)
+	if err != nil || len(pods.Items) != 1 {
+		panic(fmt.Sprintf("failed to find OSD pod: %v", err))
+	}
+
+	// Find the device path for the given pod resource
+	var deviceName string
+	for _, envVar := range pods.Items[0].Spec.Containers[0].Env {
+		if envVar.Name == "ROOK_BLOCK_PATH" {
+			deviceName = envVar.Value
+			break
+		}
+	}
+
+	// Find the descriptor for the given device
+	targetNode := pods.Items[0].Spec.NodeName
+	for _, fd := range r.fabricMap.GetDescriptorsByNode(targetNode) {
+		if fd.DeviceName == deviceName {
+			return fd
+		}
+	}
+
+	panic(fmt.Sprintf("no attached device found for OSD ID %s", osdID))
+}
+
 // cleanupOSD cleans up the OSD deployment and disconnects the device
-func (r *ReconcileNvmeOfStorage) cleanupOSD(namespace string, deviceInfo cephv1.FabricDevice) {
+func (r *ReconcileNvmeOfStorage) cleanupOSD(namespace string, fd FabricDescriptor) {
 	// Delete the OSD deployment that is in CrashLoopBackOff
-	podName := osd.AppName + "-" + deviceInfo.OsdID
+	podName := osd.AppName + "-" + fd.ID
 	if err := k8sutil.DeleteDeployment(
 		r.opManagerContext,
 		r.context.Clientset,
@@ -302,60 +327,37 @@ func (r *ReconcileNvmeOfStorage) cleanupOSD(namespace string, deviceInfo cephv1.
 	logger.Debugf("successfully deleted the OSD deployment. Name: %q", podName)
 
 	// Disconnect the device used by this OSD
-	if err := r.disconnectOSDDevice(namespace, deviceInfo); err != nil {
-		panic(fmt.Sprintf("failed to disconnect OSD device with SubNQN %s: %v", deviceInfo.SubNQN, err))
+	if err := r.disconnectOSDDevice(namespace, fd); err != nil {
+		panic(fmt.Sprintf("failed to disconnect OSD device with SubNQN %s: %v", fd.SubNQN, err))
 	}
 }
 
-func (r *ReconcileNvmeOfStorage) reassignFaultedOSDDevice(namespace string, deviceInfo cephv1.FabricDevice) cephv1.FabricDevice {
+func (r *ReconcileNvmeOfStorage) reassignFaultedOSDDevice(namespace string, fd FabricDescriptor) FabricDescriptor {
 	// Get the new host for the OSD reassignment
-	targetNode := r.fabricMap.GetNextAttachableNode(deviceInfo)
+	targetNode := r.fabricMap.GetNextAttachableNode(fd)
 	if targetNode == "" {
 		// Return an empty struct when there is no attachable node, which means this OSD will be removed and rebalanced by Ceph
-		return cephv1.FabricDevice{}
+		return FabricDescriptor{}
 	}
 
 	// Reassign the device to the new host
-	output, err := r.connectOSDDeviceToNode(namespace, targetNode, deviceInfo)
+	output, err := r.connectOSDDeviceToNode(namespace, targetNode, fd)
 	if err != nil {
 		// TODO (cheolho.kang): If connectOSDDeviceToNode fails due to an abnormal targetNode,
 		// implement logic to exclude the current targetNode and search for the next attachable node.
 		panic(fmt.Sprintf("failed to connect device with SubNQN %s to node %s: %v",
-			deviceInfo.SubNQN, targetNode, err))
+			fd.SubNQN, targetNode, err))
 	}
+	logger.Debugf("successfully reassigned the device. node: [%s --> %s], device: [%s --> %s], SubNQN: %s",
+		fd.AttachedNode, targetNode, fd.DeviceName, output, fd.SubNQN)
 
-	// Update the attached node for reassigning the device
-	r.fabricMap.AddOSD(output.OsdID, r.nvmeOfStorage)
-
-	// TODO (cheolho.kang): these lines should be moved to initialization phase. Other updatable data (e.g., device name, attached node) should be separated from CR and managed via k8s (e.g., etcd, configmap) (PBDEV-1748)
-	// Update the NvmeOfStorage CR
-	for i := range r.nvmeOfStorage.Spec.Devices {
-		device := &r.nvmeOfStorage.Spec.Devices[i]
-		if device.OsdID == deviceInfo.OsdID {
-			if output.AttachedNode == "" {
-				// it means no nodes are available for reassignment
-				// In this case, the device will be removed from the nvmeOfStorage CR
-				r.nvmeOfStorage.Spec.Devices = append(r.nvmeOfStorage.Spec.Devices[:i], r.nvmeOfStorage.Spec.Devices[i+1:]...)
-				logger.Debug("OSD.%s will not be reassigned to any node", device.OsdID)
-			} else {
-				device.AttachedNode = output.AttachedNode
-				device.DeviceName = output.DeviceName
-			}
-			break
-		}
-	}
-	err = r.client.Update(r.opManagerContext, r.nvmeOfStorage)
-	if err != nil {
-		panic(fmt.Sprintf("failed to update NVMeOfStorage: %s, error: %+v", r.nvmeOfStorage.Name, err))
-	}
-
-	logger.Debugf("successfully reassigned the device for OSD.%s. node: [%s --> %s], device: [%s --> %s], SubNQN: %s",
-		output.OsdID, deviceInfo.AttachedNode, output.AttachedNode, deviceInfo.DeviceName, output.DeviceName, output.SubNQN)
-
-	return output
+	fd.AttachedNode = targetNode
+	fd.DeviceName = output
+	r.fabricMap.AddDescriptor(fd)
+	return fd
 }
 
-func (r *ReconcileNvmeOfStorage) updateCephClusterCR(namespace string, oldDeviceInfo, newDeviceInfo cephv1.FabricDevice) error {
+func (r *ReconcileNvmeOfStorage) updateCephClusterCR(namespace string, oldDeviceInfo, newDeviceInfo FabricDescriptor) error {
 	// Fetch the CephCluster CR
 	cephCluster, err := r.context.RookClientset.CephV1().CephClusters(namespace).Get(
 		r.opManagerContext,
@@ -412,36 +414,29 @@ func (r *ReconcileNvmeOfStorage) updateCephClusterCR(namespace string, oldDevice
 }
 
 // connectOSDDeviceToNode runs a job to connect an NVMe-oF device to the target node
-func (r *ReconcileNvmeOfStorage) connectOSDDeviceToNode(namespace, targetNode string, deviceInfo cephv1.FabricDevice) (cephv1.FabricDevice, error) {
-	output := *deviceInfo.DeepCopy()
-	fd, err := r.fabricMap.FindDescriptorBySubNQN(deviceInfo.SubNQN)
-	if err != nil {
-		panic("failed to find the device with SubNQN " + deviceInfo.SubNQN)
-	}
+func (r *ReconcileNvmeOfStorage) connectOSDDeviceToNode(namespace, targetNode string, fd FabricDescriptor) (string, error) {
 	jobCode := fmt.Sprintf(nvmeofToolCode, "connect", fd.Address, fd.Port, fd.SubNQN)
 	jobOutput, err := RunJob(r.opManagerContext, r.context.Clientset, namespace, targetNode, jobCode)
 	if err != nil || !strings.Contains(jobOutput, "SUCCESS:") {
-		return output, fmt.Errorf("failed to connect NVMe-oF device. fd: %v, output: %s", fd, jobOutput)
+		return "", fmt.Errorf("failed to connect NVMe-oF device. fd: %v, output: %s", fd, jobOutput)
 	}
 
 	parts := strings.SplitN(jobOutput, "SUCCESS:", 2)
-	devicePath := strings.TrimSpace(parts[1])
-	output.DeviceName = devicePath
-	output.AttachedNode = targetNode
+	output := strings.TrimSpace(parts[1])
 
-	logger.Debugf("successfully connected NVMe-oF Device. Node: %s, DevicePath: %s, SubNQN: %s", targetNode, devicePath, fd.SubNQN)
+	logger.Debugf("successfully connected NVMe-oF Device. Node: %s, DevicePath: %s, SubNQN: %s", targetNode, output, fd.SubNQN)
 	return output, nil
 }
 
 // disconnectOSDDevice runs a job to disconnect an NVMe-oF device from the target node
-func (r *ReconcileNvmeOfStorage) disconnectOSDDevice(namespace string, fabricDeviceInfo cephv1.FabricDevice) error {
-	jobCode := fmt.Sprintf(nvmeofToolCode, "disconnect", "", "", fabricDeviceInfo.SubNQN)
-	jobOutput, err := RunJob(r.opManagerContext, r.context.Clientset, namespace, fabricDeviceInfo.AttachedNode, jobCode)
+func (r *ReconcileNvmeOfStorage) disconnectOSDDevice(namespace string, fd FabricDescriptor) error {
+	jobCode := fmt.Sprintf(nvmeofToolCode, "disconnect", "", "", fd.SubNQN)
+	jobOutput, err := RunJob(r.opManagerContext, r.context.Clientset, namespace, fd.AttachedNode, jobCode)
 	if err != nil || !strings.Contains(jobOutput, "SUCCESS:") {
-		return fmt.Errorf("failed to disconnect NVMe-oF device. fd: %v, output: %s", fabricDeviceInfo, jobOutput)
+		return fmt.Errorf("failed to disconnect NVMe-oF device. fd: %v, output: %s", fd, jobOutput)
 	}
 
-	logger.Debugf("successfully disconnected NVMe-oF Device. Node: %s, SubNQN: %s, Output: %s", fabricDeviceInfo.AttachedNode, fabricDeviceInfo.SubNQN, jobOutput)
+	logger.Debugf("successfully disconnected NVMe-oF Device. Node: %s, SubNQN: %s, Output: %s", fd.AttachedNode, fd.SubNQN, jobOutput)
 	return nil
 }
 

--- a/pkg/operator/ceph/nvmeof_recoverer/nvmeofstorage/util.go
+++ b/pkg/operator/ceph/nvmeof_recoverer/nvmeofstorage/util.go
@@ -81,7 +81,6 @@ type FabricDescriptor struct {
 	SubNQN       string
 	AttachedNode string
 	DeviceName   string
-	ClusterName  string
 }
 
 // FabricMap manages the mapping between devices and nodes

--- a/pkg/operator/ceph/nvmeof_recoverer/nvmeofstorage/util_test.go
+++ b/pkg/operator/ceph/nvmeof_recoverer/nvmeofstorage/util_test.go
@@ -3,64 +3,55 @@ package nvmeofstorage
 import (
 	"testing"
 
-	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRelocateOSD(t *testing.T) {
 	fm := NewFabricMap()
-	nvmeofstorage := &cephv1.NvmeOfStorage{
-		Spec: cephv1.NvmeOfStorageSpec{
-			Devices: []cephv1.FabricDevice{
-				{
-					SubNQN:       "com.example:subnqn0",
-					OsdID:        "0",
-					AttachedNode: "node1",
-				},
-				{
-					SubNQN:       "com.example:subnqn1",
-					OsdID:        "1",
-					AttachedNode: "node2",
-				},
-				{
-					SubNQN:       "com.example:subnqn2",
-					OsdID:        "2",
-					AttachedNode: "node2",
-				},
-				{
-					SubNQN:       "com.example:subnqn3",
-					OsdID:        "3",
-					AttachedNode: "node3",
-				},
-			},
+	fds := []FabricDescriptor{
+		{
+			SubNQN:       "com.example:subnqn0",
+			AttachedNode: "node1",
+		},
+		{
+			SubNQN:       "com.example:subnqn1",
+			AttachedNode: "node2",
+		},
+		{
+			SubNQN:       "com.example:subnqn2",
+			AttachedNode: "node2",
+		},
+		{
+			SubNQN:       "com.example:subnqn3",
+			AttachedNode: "node3",
 		},
 	}
 
-	for _, device := range nvmeofstorage.Spec.Devices {
-		fm.AddOSD(device.OsdID, nvmeofstorage)
+	for _, fd := range fds {
+		fm.AddDescriptor(fd)
 	}
 
-	t.Run("TestGetNextAttachableNode", func(t *testing.T) {
-		faultDeviceInfo := nvmeofstorage.Spec.Devices[0]
+	t.Run("TestGetNextAttachableNodeErrorHandling", func(t *testing.T) {
+		faultDeviceInfo := fds[0]
 		// "node3" will be selected as the next node because it has the fewest number of fabric device attached"
 		expectedNextNode := "node3"
 		actualNextNode := fm.GetNextAttachableNode(faultDeviceInfo)
 		require.Equal(t, expectedNextNode, actualNextNode)
 
 		// "node2" will be seletect because "node1" has been removed from the fabric map
-		faultDeviceInfo = nvmeofstorage.Spec.Devices[3]
+		faultDeviceInfo = fds[3]
 		expectedNextNode = "node2"
 		actualNextNode = fm.GetNextAttachableNode(faultDeviceInfo)
 		require.Equal(t, expectedNextNode, actualNextNode)
 
 		// any node can be selected because "node3" has also been removed from the fabric map, leaving nothing to attach.
-		faultDeviceInfo = nvmeofstorage.Spec.Devices[1]
+		faultDeviceInfo = fds[1]
 		expectedNextNode = ""
 		actualNextNode = fm.GetNextAttachableNode(faultDeviceInfo)
 		require.Equal(t, expectedNextNode, actualNextNode)
 
 		// any node will be selected
-		faultDeviceInfo = nvmeofstorage.Spec.Devices[2]
+		faultDeviceInfo = fds[2]
 		expectedNextNode = ""
 		actualNextNode = fm.GetNextAttachableNode(faultDeviceInfo)
 		require.Equal(t, expectedNextNode, actualNextNode)

--- a/tests/framework/clients/nvmeof_recoverer.go
+++ b/tests/framework/clients/nvmeof_recoverer.go
@@ -76,8 +76,7 @@ spec:
     - subnqn: "` + device.SubNQN + `"
       port: ` + fmt.Sprintf("%d", device.Port) + `
       attachedNode: "` + device.AttachedNode + `"
-      deviceName: "` + device.DeviceName + `"
-      clusterName: "` + device.ClusterName + `"`
+      deviceName: "` + device.DeviceName + `"`
 		}
 	}
 	err := n.k8sh.ResourceOperation("apply", nvmeofstorageResource)

--- a/tests/integration/ceph_nvmeof_recoverer_test.go
+++ b/tests/integration/ceph_nvmeof_recoverer_test.go
@@ -92,21 +92,18 @@ func (s *NvmeofRecovererSuite) TestBasicSingleFabricDomain() {
 				Port:         1152,
 				AttachedNode: node1,
 				DeviceName:   "/dev/nvme0n1",
-				ClusterName:  s.namespace,
 			},
 			{
 				SubNQN:       "nqn.2024-07.com.example:storage2",
 				Port:         1152,
 				AttachedNode: node2,
 				DeviceName:   "/dev/nvme1n1",
-				ClusterName:  s.namespace,
 			},
 			{
 				SubNQN:       "nqn.2024-07.com.example:storage3",
 				Port:         1152,
 				AttachedNode: node1,
 				DeviceName:   "/dev/nvme2n1",
-				ClusterName:  s.namespace,
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
